### PR TITLE
メールアドレスのplaceholderをsアドからuアドに書き換え

### DIFF
--- a/src/pages/dev-tool/assign-role.tsx
+++ b/src/pages/dev-tool/assign-role.tsx
@@ -120,7 +120,7 @@ const AssignRole: PageFC = () => {
               <TextField
                 type="text"
                 label="権限を付与するユーザーのメールアドレス"
-                placeholder="xxx@s.tsukuba.ac.jp"
+                placeholder="xxx@u.tsukuba.ac.jp"
                 required
                 error={[
                   errors.email?.types?.required && "必須項目です",

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -100,7 +100,7 @@ const Login: PageFC = () => {
                     errors?.email?.type === "userDisabled" &&
                       "アカウントが無効化されています",
                   ]}
-                  placeholder="xxx@s.tsukuba.ac.jp"
+                  placeholder="xxx@u.tsukuba.ac.jp"
                   required
                   register={register("email", {
                     required: true,

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -109,7 +109,7 @@ const ResetPassword: PageFC = () => {
                       errors?.email?.type === "userNotFound" &&
                         "ユーザーが見つかりません",
                     ]}
-                    placeholder="xxx@s.tsukuba.ac.jp"
+                    placeholder="xxx@u.tsukuba.ac.jp"
                     required
                     register={register("email", {
                       required: true,

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -124,7 +124,7 @@ const Signup: PageFC = () => {
                     emailWarning === "invalidSAddress" &&
                       "学生に発行されたsアドレスではない可能性があります。\nこのまま実行しますか？",
                   ]}
-                  placeholder="xxx@s.tsukuba.ac.jp"
+                  placeholder="xxx@u.tsukuba.ac.jp"
                   required
                   register={register("email", {
                     required: true,


### PR DESCRIPTION
表題の通りです。ロジックに関わるところは変更していなくて、見た目だけ変わりました。
sアドを受け入れるのはいいけど、一年生も論理的には（ルールが変わっていなければ）企画責任者になりうるはずなのでuにしておくのが良いように思われる。