### PR TITLE
メールの送信元表記をsystem@sohosai.comに変更/メール送信エラーが発生した際のエラーメッセージの変更

### DIFF
--- a/src/pages/email-verification.tsx
+++ b/src/pages/email-verification.tsx
@@ -52,8 +52,8 @@ const EmailVerification: PageFC = () => {
                 メールに記載されたリンクをクリックして登録を完了してください
               </p>
               <p className={styles.description}>
-                受信できない場合、noreply@
-                {process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN}
+                {/* TODO: ここ、どう考えても環境変数にするべきだけど知らん知らん!!! ごめん..... */}
+                受信できない場合、system@sohosai.com
                 からのメールが迷惑メールフォルダに配信されていないかご確認ください
               </p>
               <p className={styles.description}>
@@ -99,8 +99,9 @@ const EmailVerification: PageFC = () => {
           {emailVerificationStatus === "error" && (
             <>
               <h1 className={styles.title}>確認メールを再送できませんでした</h1>
-              <p className={styles.description}>管理者にお問い合わせください</p>
-              {/* TODO: 問い合わせへの動線 */}
+              <p className={styles.description}>
+                しばらく時間を置いてから再度お試しください
+              </p>
             </>
           )}
         </Panel>


### PR DESCRIPTION
Firebase AuthenticationにSendgridを導入し、SOSの認証メール送信元をSendgridに変更したことに伴い、メールの送信元表記をnoreply@Firebaseのドメインからsystem@sohosai.comに変更した。
また、メール送信エラーのエラーメッセージから管理者に連絡してほしいを消し、時間をおいて試すよう促すメッセージを代わりに置いた。