### PR TITLE
Sentryのデバッグを強化

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -9,9 +9,16 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_DEPLOY_ENV,
   normalizeDepth: 10,
+  // This sets the sample rate to be 10%. You may want this to be 100% while
+  // in development and sample at a lower rate in production
+  replaysSessionSampleRate: 0.1,
+  // If the entire session is not sampled, use the below sample rate to sample
+  // sessions when an error occurs.
+  replaysOnErrorSampleRate: 1.0,
   integrations: [
     new CaptureConsole({ levels: ["warn", "error", "debug", "assert"] }),
     new ExtraErrorData({ depth: 10 }),
+    new Sentry.Replay(),
   ],
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -17,7 +17,7 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   integrations: [
     new CaptureConsole({ levels: ["warn", "error", "debug", "assert"] }),
-    new ExtraErrorData({ depth: 10 }),
+    new ExtraErrorData({ depth: 50 }),
     new Sentry.Replay(),
   ],
   // Note: if you want to override the automatic release value, do not set a


### PR DESCRIPTION
デバッグの強化のため、Sentry Replay (なんか操作を画像で見れるらしい) を追加し、Sentryのエラー時に来るコンソールデータを10から50に拡大した