### PR TITLE
デバッグのため、Sentry ReplayのmaskAllText設定をfalseに設定

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -18,7 +18,11 @@ Sentry.init({
   integrations: [
     new CaptureConsole({ levels: ["warn", "error", "debug", "assert"] }),
     new ExtraErrorData({ depth: 50 }),
-    new Sentry.Replay(),
+    new Sentry.Replay({
+      //デフォルトはTrueだが、デバッグ用に必要だと判断
+      maskAllText: false,
+      blockAllMedia: true,
+    }),
   ],
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
入力文字依存のエラーなど、デバッグ用により詳細な情報が必要だと判断したため、maskAllTextをfalseに設定した