### PR TITLE
小さい画面でも企画タイトルが表示されるように

### DIFF
--- a/src/pages/committee/form/index.module.scss
+++ b/src/pages/committee/form/index.module.scss
@@ -28,7 +28,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  
+
   @mixin mobile {
     flex-wrap: wrap;
   }

--- a/src/pages/committee/form/index.module.scss
+++ b/src/pages/committee/form/index.module.scss
@@ -28,13 +28,16 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  
+  @mixin mobile {
+    flex-wrap: wrap;
+  }
 }
 
 .formName {
   flex-grow: 1;
   flex-shrink: 1;
   margin-right: 16px;
-  @include ellipsis;
 }
 
 .formDate {


### PR DESCRIPTION
fixes #1111 

- 企画タイトルのellipsisを削除
- モバイル端末で `flex-wrap: wrap` を追加

## 現状
<img width="160" alt="image" src="https://github.com/sohosai/sos-frontend/assets/53410646/580ed0f9-e213-444c-ad89-79866eb98431">

## 変更後
![image](https://github.com/sohosai/sos-frontend/assets/53410646/0dad1a66-a50b-469a-8a4d-a5c352463071)
